### PR TITLE
Bug fixes

### DIFF
--- a/bot/services/availability_service.py
+++ b/bot/services/availability_service.py
@@ -69,7 +69,7 @@ def ask_join(chat_id: int, event_id: str, thread_id: int = None):
             return
         
         # generate event description
-        event_description = generate_confirmed_event_description(event)
+        event_description = generate_confirmed_event_description(event_id)
         
         # add join button
         markup = types.InlineKeyboardMarkup()

--- a/bot/services/share_service.py
+++ b/bot/services/share_service.py
@@ -74,6 +74,7 @@ def handle_share_event(event_id: str, user_id: str, chat_id: str, message_id: st
 
     try: 
         # delete share message
+        bot.edit_message_text(chat_id=chat_id, message_id=message_id, text="Event shared successfully!")
         bot.delete_message(chat_id=chat_id, message_id=message_id)
     except Exception as e:
         logger.error(f"Error in handle_share_event: {str(e)}")

--- a/bot/telegram/handlers/event_handlers.py
+++ b/bot/telegram/handlers/event_handlers.py
@@ -153,13 +153,6 @@ def handle_event_creation(message, data):
         
         # Create share button
         markup = types.InlineKeyboardMarkup()
-
-        # Add share button
-        share_button = types.InlineKeyboardButton(
-            text="Share Event",
-            switch_inline_query=f"{event_id}"
-        )
-        markup.add(share_button)
         
         # Add confirm button
         params = f"event_id={event_id}"
@@ -178,7 +171,7 @@ def handle_event_creation(message, data):
         # Send confirmation message
         bot.reply_to(
             message,
-            f"Event created successfully!\n\n{generated_description}\n\nShare this event with others:",
+            f"Event created successfully!\n\n{generated_description}\n\nShare this event with others using the /share command in your group chats! \n\nConfirm the event here when you're ready!",
             reply_markup=markup
         )
         
@@ -222,29 +215,28 @@ def handle_event_confirmation(event_id, best_start_time, best_end_time):
             # event failed to confirm
             message = f"Failed to confirm event {event['event_name']}."
             bot.send_message(creator_tele_id, message)
-        else:
-            # event confirmed successfully
-            print("Event confirmed successfully.")
-            message = f"Event {event['event_name']} confirmed successfully."
-            bot.send_message(chat_id=creator_tele_id, text=message)
-            print("Message should be sent to creator ", creator["tele_user"])
-            # add participants to event
-            for participant in participants:
-                success = join_event_by_uuid(event_id, participant)
-                if not success:
-                    bot.send_message(chat_id=creator_tele_id, text=f"Failed to add participant to event.")
-            print("participants", participants)
-            # create share message
-            description = generate_confirmed_event_description(event_id)
+            return
+        # event confirmed successfully
+        print("Event confirmed successfully.")
 
-            text = f"Event {event['event_name']} confirmed successfully.\n\n{description}\n\nShare this event with others using the /share command in your group chats!"
+        print("Message should be sent to creator ", creator["tele_user"])
+        # add participants to event
+        for participant in participants:
+            success = join_event_by_uuid(event_id, participant)
+            if not success:
+                bot.send_message(chat_id=creator_tele_id, text=f"Failed to add participant to event.")
+        print("participants", participants)
+        # create share message
+        description = generate_confirmed_event_description(event_id)
 
-            bot.send_message(chat_id=creator_tele_id, text=text)
+        text = f"Event {event['event_name']} confirmed successfully.\n\n{description}\n\nShare this event with others using the /share command in your group chats!"
 
-            # send availability to event chat
-            chat_id, thread_id = get_event_chat(event_id)
-            if chat_id:
-                ask_join(chat_id, event_id, thread_id)
+        bot.send_message(chat_id=creator_tele_id, text=text)
+
+        # send availability to event chat
+        chat_id, thread_id = get_event_chat(event_id)
+        if chat_id:
+            ask_join(chat_id, event_id, thread_id)
     except Exception as e:
         bot.send_message(chat_id=creator_tele_id, text=f"Error confirming event: {str(e)}")
         return

--- a/shared/database/schema.sql
+++ b/shared/database/schema.sql
@@ -29,9 +29,9 @@ CREATE TABLE users (
 -- 2) Events
 CREATE TABLE events (
   event_id        UUID            PRIMARY KEY,
-    event_name      VARCHAR(255)    NOT NULL,
-    event_description VARCHAR(255)    NOT NULL,    
-    event_type      VARCHAR(255)    NOT NULL,
+  event_name      TEXT    NOT NULL,
+  event_description TEXT    NOT NULL,    
+  event_type      TEXT    NOT NULL,
   start_date      TIMESTAMPTZ       NOT NULL,      
   end_date        TIMESTAMPTZ       NOT NULL,      
   start_hour     TIMETZ         NOT NULL DEFAULT '00:00:00.000000+08:00',
@@ -40,7 +40,7 @@ CREATE TABLE events (
   min_duration INT NOT NULL DEFAULT 2, -- in terms of blocks
   max_duration INT NOT NULL DEFAULT 4, -- in terms of blocks
   is_reminders_enabled BOOLEAN NOT NULL DEFAULT false,
-  timezone VARCHAR(255) NOT NULL DEFAULT 'Asia/Singapore',
+  timezone TEXT NOT NULL DEFAULT 'Asia/Singapore',
   creator         UUID            NOT NULL
                     REFERENCES users(uuid)
                     ON DELETE RESTRICT,

--- a/webapp/app/share/page.tsx
+++ b/webapp/app/share/page.tsx
@@ -184,30 +184,15 @@ export default function SharePage() {
                 <p className="text-sm text-gray-500 mt-1">
                   Event ID: {event.id}
                 </p>
-                <p className="text-xs text-blue-600 mt-2">
-                  Click to select this event
-                </p>
                 <div className="mt-3 flex space-x-2">
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      window.open(
-                        `/dragselector?event_id=${event.id}&tele_id=${tele_id}`,
-                        "_blank"
-                      );
-                    }}
-                    className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm transition-colors"
-                  >
-                    Set Availability
-                  </button>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      window.open(`/confirm?event_id=${event.id}`, "_blank");
+                      window.location.href = `/confirm?event_id=${event.id}`;
                     }}
                     className="bg-green-500 hover:bg-green-600 text-white px-3 py-1 rounded text-sm transition-colors"
                   >
-                    View Details
+                    Confirm Event
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
This pull request introduces several changes across the bot backend and webapp frontend to improve the event sharing and confirmation workflow, as well as updates to the database schema for better compatibility and flexibility. The main themes are user experience improvements, backend logic adjustments, and database schema updates.

**User Experience Improvements (Frontend & Bot Responses):**
* The webapp's share page (`webapp/app/share/page.tsx`) now replaces "Set Availability" with a direct "Confirm Event" button, which navigates users to the confirmation page instead of opening a new window. The "Click to select this event" prompt and the previous availability button have been removed for a more streamlined interface.
* Telegram bot confirmation messages have been updated to instruct users to use the `/share` command in their group chats instead of relying on an inline share button, which has been removed from the event creation flow. [[1]](diffhunk://#diff-373440943cf8fda81e4c1ccf6272d77e094957024eb6f5408343b0cc9178b63dL157-L163) [[2]](diffhunk://#diff-373440943cf8fda81e4c1ccf6272d77e094957024eb6f5408343b0cc9178b63dL181-R174)

**Backend Logic Adjustments:**
* The event description is now generated using the event ID instead of the event object in the availability service, ensuring consistency and possibly reducing errors.
* In the share service, after sharing an event, a success message is edited into the chat before the share message is deleted, providing better feedback to users.
* The event confirmation handler has been adjusted to ensure that a message is only sent to the creator when confirmation fails, preventing duplicate or unnecessary success messages.

**Database Schema Updates:**
* The `events` table in `shared/database/schema.sql` now uses `TEXT` instead of `VARCHAR(255)` for several fields (`event_name`, `event_description`, `event_type`, and `timezone`), allowing for greater flexibility in storing longer strings. [[1]](diffhunk://#diff-4ec6b5e433998d1a12e8b1221219f1bd3a1a2086ad43170bb874a10b219539bcL32-R34) [[2]](diffhunk://#diff-4ec6b5e433998d1a12e8b1221219f1bd3a1a2086ad43170bb874a10b219539bcL43-R43)